### PR TITLE
RIP Vice

### DIFF
--- a/gothamgrabber.py
+++ b/gothamgrabber.py
@@ -88,6 +88,20 @@ def scrape_villagevoice_page(url):
 
     return links
 
+def scrape_vice_page(url):
+    headers={'User-Agent':'gothamgrabber'}
+    res = requests.get(url, headers=headers)
+    soup = BeautifulSoup(res.text, 'html.parser')
+    arts = soup.findAll('h3', {'class':'vice-card__vice-card-hed'})
+    links = ["http://www.vice.com" + art.find('a')['href'] for art in arts]
+    print("Adding {} links to be scraped.".format(len(links)))
+    next_button = soup.findAll('a', {'class':'pagination-page__next-link'})
+    if next_button:
+        next_url = "http://www.vice.com" + next_button[0]['href']
+        print(next_url, next_button[0])
+        links.extend(scrape_vice_page(next_url))
+
+    return links
 
 def log_errors(url, dirname, error_bytes):
     filename = "errors.log"
@@ -154,6 +168,12 @@ def main():
             lastname = names[0]
             links = scrape_villagevoice_page(url)
 
+        elif 'vice.com' in spliturl.netloc:
+            print("Scraping Vice page.")
+            names = [slug, 'vice']
+            lastname = names[0]
+            links = scrape_vice_page(url)
+
         else:
             print("""Link must be to a page on one of the following sites:
             -- Gothamist network
@@ -161,7 +181,8 @@ def main():
             -- LA Weekly
             -- Newsweek
             -- Kinja
-            -- Village Voice""")
+            -- Village Voice
+            -- Vice""")
             return
 
         filename = "-".join(names) + ".txt"

--- a/grabber.js
+++ b/grabber.js
@@ -74,6 +74,10 @@ async function timeout(ms) {
         pdf_options.scale = .75;
     }
 
+    if (url.includes('vice.com')) {
+        await page.addStyleTag({path: 'tweaks/vice.css'});
+    }
+
     if (argv.k) {
         await page.addStyleTag({path: 'tweaks/kinja.css'});
         await page.setViewport({width:500, height: 600});

--- a/tweaks/vice.css
+++ b/tweaks/vice.css
@@ -1,0 +1,9 @@
+.navbar-wrapper,
+.article__socialize,
+.adph,
+.user-newsletter-signup,
+.recirc-footer,
+.inbody-article,
+footer {
+    display: none;
+}


### PR DESCRIPTION
Add support for [Vice](https://vice.com/).

New York Times: [Vice’s New Owners Prepare to Slash What’s Left of Its Work Force](https://www.nytimes.com/2024/02/22/business/vice-media-layoffs.html):
> When Vice emerged from bankruptcy last year, some observers hoped its new owners — a consortium led by the private-equity firm Fortress Investment Group — would reinvest to return the company to growth.
>
> Instead, Fortress has decided to make sweeping cuts, as part of an attempt to stem the endless tide of red ink. The company is planning to inform employees of its new business strategy in the next week.
>
> Mr. Dixon also said in the memo, which was seen by The New York Times, that the company would no longer publish on Vice.com.

New York Magazine: [Vice Is Basically Dead](https://nymag.com/intelligencer/article/vice-media-is-basically-dead.html)

> A rumor on Thursday morning frightened many journalists who had written for [Vice Media](https://nymag.com/intelligencer/2018/06/inside-vice-media-shane-smith.html): Thousands of stories written over the past two decades [could soon be deleted](https://www.mediaite.com/media/its-apocalyptic-vice-staffers-brace-for-worst-after-anonymous-tip-warns-site-will-be-deleted-entirely/) without any warning. Inside the irreverent company, which began as a scabrous print magazine in Montreal and later helped define the tone of early digital media, the mood was tense. According to the [Hollywood Reporter](https://www.hollywoodreporter.com/business/business-news/vice-news-top-editor-tells-staff-he-doesnt-know-if-website-will-shutter-1235832668/), editors asked top brass for an answer — or at least a denial of the rumor — and did not hear back.
>
> Hours later, staffers found out why. In a message to staff, CEO Bruce Dixon said that several hundred of Vice’s remaining 900 employees will soon be laid off in a restructuring that essentially kills off the editorial brand.
>
> After the mass layoff, Vice will still exist, kind of. No more stories will be published on Vice.com.

The Verge: [Vice is abandoning Vice.com and laying off hundreds](https://www.theverge.com/2024/2/22/24080497/vice-media-website-layoffs)

> Vice writers began backing up their content [after an anonymous tip](https://twitter.com/janusrose/status/1760683182389956757) suggested the site would be shutting down. It’s still not clear whether Vice will shutter its website altogether — as we’ve seen with [The Messenger](https://www.theverge.com/2024/1/31/24057375/the-messenger-is-reportedly-shutting-down-after-less-than-a-year) — or if the website will remain online but inactive.
